### PR TITLE
Map port 8000 so the Rest API is available

### DIFF
--- a/shell
+++ b/shell
@@ -1,1 +1,1 @@
-docker run -v `pwd`:/docker -p 9000:9000 --rm -i -t predictionio /bin/bash
+docker run -v `pwd`:/docker -p 9000:9000 -p 8000:8000 --rm -i -t predictionio /bin/bash


### PR DESCRIPTION
I started following the [quickstart guide](http://docs.prediction.io/current/tutorials/quickstart-php.html) and quickly ran into problems. After I mapped port 8000, things worked fine.
