### PR TITLE
Support for multiple engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,7 @@ Run [quickstart](http://docs.prediction.io/templates/recommendation/quickstart/)
 3. Deploy Engine ```cd MyRecommendation && pio deploy --ip 0.0.0.0&```
 4. Your Engine will now listen on port 8000
 
+Run [Multiple Engines]()
 
+1. On deployment of the second Engine, run ```pio deploy --ip 0.0.0.0 --port 8001 &```
+2. For additional engines, use 8001-8006

--- a/shell
+++ b/shell
@@ -1,1 +1,1 @@
-docker run -v `pwd`:/docker -p 9000:9000 -p 8000:8000 -p 7070:7070 --rm -i -t predictionio /bin/bash
+docker run -v `pwd`:/docker -p 9000:9000 -p 8000:8000 -p 8001:8001 -p 8002:8002 -p 8003:8003 -p 8004:8004 -p 8005:8005 -p 8006:8006 -p 7070:7070 --rm -i -t predictionio /bin/bash


### PR DESCRIPTION
Hi,

I used your template to setup PredictionIO locally, but noticed that it is only setup with one engine port forwarded.  I've added some additional open ports.

This enables other ports so that multiple engines may be run using this docker template