### PR TITLE
HBase Version Update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN wget -O - https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch
 RUN mv /elasticsearch* /elasticsearch
 
 #HBase
-RUN wget -O - http://www-us.apache.org/dist/hbase/1.2.6.1/hbase-1.2.6.1-bin.tar.gz | tar zx
+RUN wget -O - http://www-us.apache.org/dist/hbase/1.2.7/hbase-1.2.7-bin.tar.gz | tar zx
 RUN mv /hbase* /hbase
 RUN echo "export JAVA_HOME=/usr/lib/jvm/java-8-oracle" >> /hbase/conf/hbase-env.sh 
 


### PR DESCRIPTION
HBase just updated their version from `1.2.6.1` to `1.2.7` at 2018-09-16
The previous address for `1.2.6.1` had expired.

Only after changing the version in `Dockerfile` can the build proceed.